### PR TITLE
[16.0][FW] storage_backend_sftp: fix move_files

### DIFF
--- a/.oca/oca-port/blacklist/storage_backend_sftp.json
+++ b/.oca/oca-port/blacklist/storage_backend_sftp.json
@@ -1,0 +1,7 @@
+{
+  "pull_requests": {
+    "orphaned_commits": "False positive",
+    "78": "(auto) Nothing to port from PR #78",
+    "106": "(auto) Nothing to port from PR #106"
+  }
+}

--- a/storage_backend_sftp/components/sftp_adapter.py
+++ b/storage_backend_sftp/components/sftp_adapter.py
@@ -102,11 +102,11 @@ class SFTPStorageBackendAdapter(Component):
 
     def move_files(self, files, destination_path):
         _logger.debug("mv %s %s", files, destination_path)
-        fp = self._fullpath
+        destination_full_path = self._fullpath(destination_path)
         with sftp(self.collection) as client:
             for sftp_file in files:
                 dest_file_path = os.path.join(
-                    destination_path, os.path.basename(sftp_file)
+                    destination_full_path, os.path.basename(sftp_file)
                 )
                 # Remove existing file at the destination path (an error is raised
                 # otherwise)
@@ -116,8 +116,9 @@ class SFTPStorageBackendAdapter(Component):
                     _logger.debug("destination %s is free", dest_file_path)
                 else:
                     client.unlink(dest_file_path)
-                # Move the file using absolute filepaths
-                client.rename(fp(sftp_file), fp(dest_file_path))
+                # Move the file
+                full_path = self._fullpath(sftp_file)
+                client.rename(full_path, dest_file_path)
 
     def delete(self, relative_path):
         full_path = self._fullpath(relative_path)

--- a/storage_backend_sftp/tests/test_sftp.py
+++ b/storage_backend_sftp/tests/test_sftp.py
@@ -101,20 +101,18 @@ class SftpCase(CommonCase, BackendStorageTestMixin):
         client.lstat.side_effect = FileNotFoundError()
         to_move = "move/from/path/myfile.txt"
         to_path = "move/to/path"
+        fullpath_from = self.backend.directory_path + "/" + to_move
+        fullpath_to = fullpath_from.replace("/from", "/to")
         self.backend.move_files([to_move], to_path)
         # no need to delete it
         client.unlink.assert_not_called()
         # rename gets called
-        client.rename.assert_called_with(
-            "upload/" + to_move, "upload/" + to_move.replace("from", "to")
-        )
+        client.rename.assert_called_with(fullpath_from, fullpath_to)
         # now try to override destination
         client.lstat.side_effect = None
         client.lstat.return_value = True
         self.backend.move_files([to_move], to_path)
         # client will delete it first
-        client.unlink.assert_called_with(to_move.replace("from", "to"))
+        client.unlink.assert_called_with(fullpath_to)
         # then move it
-        client.rename.assert_called_with(
-            "upload/" + to_move, "upload/" + to_move.replace("from", "to")
-        )
+        client.rename.assert_called_with(fullpath_from, fullpath_to)


### PR DESCRIPTION
Port of `#262` from `14.0` to `16.0`.

The following PRs have been blacklisted:
- #: False positive
- `#78`: (auto) Nothing to port from `PR #78`
- `#106`: (auto) Nothing to port from `PR #106`